### PR TITLE
DPR2-1499: Add File Transfer In option to Ingestion pipeline and related Lambda changes

### DIFF
--- a/modules/domains/antivirus-check-lambda/main.tf
+++ b/modules/domains/antivirus-check-lambda/main.tf
@@ -1,4 +1,7 @@
 module "landing_zone_antivirus_check_lambda" {
+  #checkov:skip=CKV_TF_1: "Ensure Terraform module sources use a commit hash"
+  #checkov:skip=CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
+  # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/ministryofjustice/modernisation-platform-environments.git//terraform/environments/digital-prison-reporting/modules/lambdas/container-image?ref=main"
 
   enable_lambda = var.enable

--- a/modules/domains/antivirus-check-lambda/main.tf
+++ b/modules/domains/antivirus-check-lambda/main.tf
@@ -1,13 +1,11 @@
 module "landing_zone_antivirus_check_lambda" {
   source = "git::https://github.com/ministryofjustice/modernisation-platform-environments.git//terraform/environments/digital-prison-reporting/modules/lambdas/container-image?ref=main"
 
-  enable_lambda      = var.enable
-  image_uri          = "${var.ecr_repository_url}:${var.image_version}"
-  name               = var.name
-  tracing            = "Active"
-  lambda_trigger     = true
-  trigger_bucket_arn = var.trigger_bucket_arn
-  policies           = var.policies
+  enable_lambda = var.enable
+  image_uri     = "${var.ecr_repository_url}:${var.image_version}"
+  name          = var.name
+  tracing       = "Active"
+  policies      = var.policies
 
   memory_size                    = var.memory_size
   timeout                        = var.timeout
@@ -33,22 +31,4 @@ module "landing_zone_antivirus_check_lambda" {
       Jira          = "DPR2-1499"
     }
   )
-}
-
-# Each prefix in the S3 landing bucket needs to trigger the antivirus check lambda
-resource "aws_s3_bucket_notification" "aws-lambda-trigger" {
-  count = var.enable ? 1 : 0
-
-  bucket = var.antivirus_trigger_bucket_name
-
-  dynamic "lambda_function" {
-    for_each = var.bucket_prefixes
-    content {
-      lambda_function_arn = module.landing_zone_antivirus_check_lambda.lambda_function_arn
-      events              = ["s3:ObjectCreated:*"]
-      filter_prefix       = lambda_function.value
-    }
-  }
-
-  depends_on = [module.landing_zone_antivirus_check_lambda.lambda_function_arn]
 }

--- a/modules/domains/antivirus-check-lambda/outputs.tf
+++ b/modules/domains/antivirus-check-lambda/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_name" {
+  description = "The name of the Lambda function"
+  value       = var.enable ? module.landing_zone_antivirus_check_lambda.lambda_name : ""
+}

--- a/modules/domains/antivirus-check-lambda/variables.tf
+++ b/modules/domains/antivirus-check-lambda/variables.tf
@@ -8,11 +8,6 @@ variable "enable" {
   description = "Whether to enable the lambda related resources or not"
 }
 
-variable "trigger_bucket_arn" {
-  description = "Lambda Trigger S3 Bucket ARN"
-  type        = string
-}
-
 variable "ecr_repository_url" {
   description = "The URL of the ECR repository hosting the container image"
   type        = string
@@ -33,11 +28,6 @@ variable "security_group_ids" {
   type        = list(string)
 }
 
-variable "antivirus_trigger_bucket_name" {
-  description = "S3 Bucket name for the lambda trigger"
-  type        = string
-}
-
 variable "output_bucket_name" {
   description = "The name of the bucket where files passing the antivirus check are moved to"
   type        = string
@@ -46,11 +36,6 @@ variable "output_bucket_name" {
 variable "quarantine_bucket_name" {
   description = "he name of the bucket where files failing the antivirus check are moved to"
   type        = string
-}
-
-variable "bucket_prefixes" {
-  description = "The prefixes in S3 that will trigger the antivirus lambda, i.e. the prefixes used when ingesting data and in the raw, structured, curated, etc. zones"
-  type        = list(string)
 }
 
 variable "log_retention_in_days" {

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -142,7 +142,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : var.file_transfer_in ? local.empty_landing_processing_raw_archive_structured_and_curated_data : local.empty_raw_archive_structured_and_curated_data.StepName
+      "Next" : var.file_transfer_in ? local.empty_landing_processing_raw_archive_structured_and_curated_data.StepName : local.empty_raw_archive_structured_and_curated_data.StepName
     }
   }
 

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -433,7 +433,7 @@ locals {
         "NumberOfWorkers" : var.retention_curated_num_workers,
         "WorkerType" : var.retention_curated_worker_type
       },
-      "Next" : var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName
+      "Next" : var.file_transfer_in ? local.switch_hive_tables_for_prisons_to_curated.StepName : (var.batch_only ? local.run_reconciliation_job.StepName : local.resume_dms_replication_task.StepName)
     }
   }
 
@@ -574,7 +574,6 @@ module "data_ingestion_pipeline" {
       (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
       (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
       (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
-      (local.run_reconciliation_job.StepName) : local.run_reconciliation_job.StepDefinition,
       (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
       (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
     }

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -199,8 +199,6 @@ locals {
               }
             }
           ],
-          "ignoreDmsTaskFailure" : var.pipeline_notification_lambda_function_ignore_dms_failure,
-          "replicationTaskArn" : var.dms_replication_task_arn
         },
         "FunctionName" : var.landing_zone_antivirus_check_lambda_function
       },

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -198,7 +198,7 @@ locals {
                 }
               }
             }
-          ],
+          ]
         },
         "FunctionName" : var.landing_zone_antivirus_check_lambda_function
       },
@@ -239,7 +239,7 @@ locals {
                 }
               }
             }
-          ],
+          ]
         },
         "FunctionName" : var.landing_zone_processing_lambda_function
       },

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -142,7 +142,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : local.empty_raw_archive_structured_and_curated_data.StepName
+      "Next" : var.file_transfer_in ? local.empty_landing_processing_raw_archive_structured_and_curated_data: local.empty_raw_archive_structured_and_curated_data.StepName
     }
   }
 
@@ -159,6 +159,106 @@ locals {
         }
       },
       "Next" : local.start_dms_replication_task.StepName
+    }
+  }
+
+  empty_landing_processing_raw_archive_structured_and_curated_data = {
+    "StepName" : "Empty Landing Processing, Raw, Archive, Structured and Curated Data",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "Resource" : "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters" : {
+        "JobName" : var.glue_s3_data_deletion_job,
+        "Arguments" : {
+          "--dpr.file.deletion.buckets" : "${var.s3_landing_processing_bucket_id},${var.s3_raw_bucket_id},${var.s3_raw_archive_bucket_id},${var.s3_structured_bucket_id},${var.s3_curated_bucket_id}",
+          "--dpr.config.key" : var.domain
+        }
+      },
+      "Next" : var.file_transfer_in ? local.invoke_landing_zone_antivirus_check_lambda: local.start_dms_replication_task.StepName
+    }
+  }
+
+  invoke_landing_zone_antivirus_check_lambda = {
+    "StepName" : "Invoke Landing Zone Antivirus Check Lambda",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "TimeoutSeconds" : var.pipeline_landing_lambda_time_out,
+      "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "Parameters" : {
+        "Payload" : {
+          "stepFunctionToken.$" : "$$.Task.Token",
+          "Records": [ # We use this payload structure to be consistent with the structure used by S3 object notifications
+            {
+              "s3": {
+                "bucket": {
+                  "name": var.s3_landing_bucket_id
+                },
+                "object": {
+                  "key": var.domain
+                }
+              }
+            }
+          ],
+          "ignoreDmsTaskFailure" : var.pipeline_notification_lambda_function_ignore_dms_failure,
+          "replicationTaskArn" : var.dms_replication_task_arn
+        },
+        "FunctionName" : var.landing_zone_antivirus_check_lambda_function
+      },
+      "Retry" : [
+        {
+          "ErrorEquals" : [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds" : 60,
+          "MaxAttempts" : 2,
+          "BackoffRate" : 2
+        }
+      ],
+      "Next" : local.invoke_landing_zone_processing_lambda.StepName
+    }
+  }
+
+  invoke_landing_zone_processing_lambda = {
+    "StepName" : "Invoke Landing Zone Processing Lambda",
+    "StepDefinition" : {
+      "Type" : "Task",
+      "TimeoutSeconds" : var.pipeline_landing_lambda_time_out,
+      "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
+      "Parameters" : {
+        "Payload" : {
+          "stepFunctionToken.$" : "$$.Task.Token",
+          "Records": [ # We use this payload structure to be consistent with the structure used by S3 object notifications
+            {
+              "s3": {
+                "bucket": {
+                  "name": var.s3_landing_processing_bucket_id
+                },
+                "object": {
+                  "key": var.domain
+                }
+              }
+            }
+          ],
+        },
+        "FunctionName" : var.landing_zone_processing_lambda_function
+      },
+      "Retry" : [
+        {
+          "ErrorEquals" : [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds" : 60,
+          "MaxAttempts" : 2,
+          "BackoffRate" : 2
+        }
+      ],
+      "Next" : local.run_glue_batch_job.StepName
     }
   }
 
@@ -457,7 +557,28 @@ module "data_ingestion_pipeline" {
 
   step_function_execution_role_arn = var.step_function_execution_role_arn
 
-  definition = var.batch_only ? jsonencode(
+  definition = var.file_transfer_in ? jsonencode({
+    "Comment" : "Data Ingestion Pipeline Step Function (File Transfer In Batch Only)",
+    "StartAt" : local.update_hive_tables.StepName,
+    "States" : {
+      (local.update_hive_tables.StepName) : local.update_hive_tables.StepDefinition,
+      (local.prepare_temp_reload_bucket_data.StepName) : local.prepare_temp_reload_bucket_data.StepDefinition,
+      (local.copy_curated_data_to_temp_reload_bucket.StepName) : local.copy_curated_data_to_temp_reload_bucket.StepDefinition,
+      (local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepName) : local.switch_hive_tables_for_prisons_to_temp_reload_bucket.StepDefinition,
+      (local.empty_landing_processing_raw_archive_structured_and_curated_data.StepName) : local.empty_landing_processing_raw_archive_structured_and_curated_data.StepDefinition,
+      (local.invoke_landing_zone_antivirus_check_lambda.StepName) : local.invoke_landing_zone_antivirus_check_lambda.StepDefinition,
+      (local.invoke_landing_zone_processing_lambda.StepName) : local.invoke_landing_zone_processing_lambda.StepDefinition,
+      (local.run_glue_batch_job.StepName) : local.run_glue_batch_job.StepDefinition,
+      (local.archive_raw_data.StepName) : local.archive_raw_data.StepDefinition,
+      (local.run_compaction_job_on_structured_zone.StepName) : local.run_compaction_job_on_structured_zone.StepDefinition,
+      (local.run_vacuum_job_on_structured_zone.StepName) : local.run_vacuum_job_on_structured_zone.StepDefinition,
+      (local.run_compaction_job_on_curated_zone.StepName) : local.run_compaction_job_on_curated_zone.StepDefinition,
+      (local.run_vacuum_job_on_curated_zone.StepName) : local.run_vacuum_job_on_curated_zone.StepDefinition,
+      (local.run_reconciliation_job.StepName) : local.run_reconciliation_job.StepDefinition,
+      (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
+      (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
+    }
+  }) : var.batch_only ? jsonencode(
     {
       "Comment" : "Data Ingestion Pipeline Step Function (Batch Only)",
       "StartAt" : local.stop_dms_replication_task.StepName,

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -194,7 +194,7 @@ locals {
                   "name" : var.s3_landing_bucket_id
                 },
                 "object" : {
-                  "key" : var.domain
+                  "key" : var.domain_s3_prefix
                 }
               }
             }
@@ -237,7 +237,7 @@ locals {
                   "name" : var.s3_landing_processing_bucket_id
                 },
                 "object" : {
-                  "key" : var.domain
+                  "key" : var.domain_s3_prefix
                 }
               }
             }

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -142,7 +142,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : var.file_transfer_in ? local.empty_landing_processing_raw_archive_structured_and_curated_data: local.empty_raw_archive_structured_and_curated_data.StepName
+      "Next" : var.file_transfer_in ? local.empty_landing_processing_raw_archive_structured_and_curated_data : local.empty_raw_archive_structured_and_curated_data.StepName
     }
   }
 
@@ -174,7 +174,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : var.file_transfer_in ? local.invoke_landing_zone_antivirus_check_lambda: local.start_dms_replication_task.StepName
+      "Next" : var.file_transfer_in ? local.invoke_landing_zone_antivirus_check_lambda : local.start_dms_replication_task.StepName
     }
   }
 
@@ -187,14 +187,14 @@ locals {
       "Parameters" : {
         "Payload" : {
           "stepFunctionToken.$" : "$$.Task.Token",
-          "Records": [ # We use this payload structure to be consistent with the structure used by S3 object notifications
+          "Records" : [ # We use this payload structure to be consistent with the structure used by S3 object notifications
             {
-              "s3": {
-                "bucket": {
-                  "name": var.s3_landing_bucket_id
+              "s3" : {
+                "bucket" : {
+                  "name" : var.s3_landing_bucket_id
                 },
-                "object": {
-                  "key": var.domain
+                "object" : {
+                  "key" : var.domain
                 }
               }
             }
@@ -230,14 +230,14 @@ locals {
       "Parameters" : {
         "Payload" : {
           "stepFunctionToken.$" : "$$.Task.Token",
-          "Records": [ # We use this payload structure to be consistent with the structure used by S3 object notifications
+          "Records" : [ # We use this payload structure to be consistent with the structure used by S3 object notifications
             {
-              "s3": {
-                "bucket": {
-                  "name": var.s3_landing_processing_bucket_id
+              "s3" : {
+                "bucket" : {
+                  "name" : var.s3_landing_processing_bucket_id
                 },
-                "object": {
-                  "key": var.domain
+                "object" : {
+                  "key" : var.domain
                 }
               }
             }
@@ -578,7 +578,7 @@ module "data_ingestion_pipeline" {
       (local.switch_hive_tables_for_prisons_to_curated.StepName) : local.switch_hive_tables_for_prisons_to_curated.StepDefinition,
       (local.empty_temp_reload_bucket_data.StepName) : local.empty_temp_reload_bucket_data.StepDefinition
     }
-  }) : var.batch_only ? jsonencode(
+    }) : var.batch_only ? jsonencode(
     {
       "Comment" : "Data Ingestion Pipeline Step Function (Batch Only)",
       "StartAt" : local.stop_dms_replication_task.StepName,

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -174,7 +174,7 @@ locals {
           "--dpr.config.key" : var.domain
         }
       },
-      "Next" : var.file_transfer_in ? local.invoke_landing_zone_antivirus_check_lambda : local.start_dms_replication_task.StepName
+      "Next" : var.file_transfer_in ? local.invoke_landing_zone_antivirus_check_lambda.StepName : local.start_dms_replication_task.StepName
     }
   }
 

--- a/modules/domains/ingestion-pipeline/pipeline.tf
+++ b/modules/domains/ingestion-pipeline/pipeline.tf
@@ -182,7 +182,7 @@ locals {
     "StepName" : "Invoke Landing Zone Antivirus Check Lambda",
     "StepDefinition" : {
       "Type" : "Task",
-      "TimeoutSeconds" : var.pipeline_landing_lambda_time_out,
+      "TimeoutSeconds" : var.landing_zone_antivirus_check_lambda_timeout_in_seconds,
       "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
       "Parameters" : {
         "Payload" : {
@@ -225,7 +225,7 @@ locals {
     "StepName" : "Invoke Landing Zone Processing Lambda",
     "StepDefinition" : {
       "Type" : "Task",
-      "TimeoutSeconds" : var.pipeline_landing_lambda_time_out,
+      "TimeoutSeconds" : var.landing_zone_processing_lambda_timeout_in_seconds,
       "Resource" : "arn:aws:states:::lambda:invoke.waitForTaskToken",
       "Parameters" : {
         "Payload" : {

--- a/modules/domains/ingestion-pipeline/variables.tf
+++ b/modules/domains/ingestion-pipeline/variables.tf
@@ -5,6 +5,12 @@ variable "setup_data_ingestion_pipeline" {
   default     = false
 }
 
+variable "file_transfer_in" {
+  description = "Determines if the pipeline is for File Transfer In, True or False?"
+  type        = bool
+  default     = false
+}
+
 variable "batch_only" {
   description = "Determines if the pipeline is batch only, True or False?"
   type        = bool
@@ -31,6 +37,12 @@ variable "pipeline_dms_task_time_out" {
   description = "DMS Task Timeout"
   type        = number
   default     = 86400 # 24 hours
+}
+
+variable "pipeline_landing_lambda_time_out" {
+  description = "Landing Zone Lambda Tasks Timeout"
+  type        = number
+  default     = 1200 # 20 minutes
 }
 
 variable "step_function_execution_role_arn" {
@@ -75,6 +87,16 @@ variable "cdc_replication_task_id" {
 
 variable "pipeline_notification_lambda_function" {
   description = "Pipeline Notification Lambda Name"
+  type        = string
+}
+
+variable "landing_zone_antivirus_check_lambda_function" {
+  description = "Landing Zone Antivirus Check Lambda Name"
+  type        = string
+}
+
+variable "landing_zone_processing_lambda_function" {
+  description = "Landing Zone Processing Lambda Name"
   type        = string
 }
 
@@ -133,6 +155,16 @@ variable "glue_reconciliation_job_num_workers" {
 
 variable "s3_glue_bucket_id" {
   description = "S3, Glue Bucket ID"
+  type        = string
+}
+
+variable "s3_landing_bucket_id" {
+  description = "S3, Landing Processing Bucket ID"
+  type        = string
+}
+
+variable "s3_landing_processing_bucket_id" {
+  description = "S3, Landing Processing Bucket ID"
   type        = string
 }
 

--- a/modules/domains/ingestion-pipeline/variables.tf
+++ b/modules/domains/ingestion-pipeline/variables.tf
@@ -372,3 +372,8 @@ variable "domain" {
   type        = string
   description = "Domain Name"
 }
+
+variable "domain_s3_prefix" {
+  type        = string
+  description = "The prefix used by the Domain in S3"
+}

--- a/modules/domains/ingestion-pipeline/variables.tf
+++ b/modules/domains/ingestion-pipeline/variables.tf
@@ -42,13 +42,13 @@ variable "pipeline_dms_task_time_out" {
 variable "landing_zone_antivirus_check_lambda_timeout_in_seconds" {
   description = "Timeout for the Landing Zone Antivirus Check Lambda in seconds"
   type        = number
-  default     = 1200 # 20 minutes
+  default     = 900 # 15 minutes
 }
 
 variable "landing_zone_processing_lambda_timeout_in_seconds" {
   description = "Landing zone processing Lambda timeout in seconds."
   type        = number
-  default     = 1200 # 20 minutes
+  default     = 900 # 15 minutes
 }
 
 variable "step_function_execution_role_arn" {

--- a/modules/domains/ingestion-pipeline/variables.tf
+++ b/modules/domains/ingestion-pipeline/variables.tf
@@ -39,8 +39,14 @@ variable "pipeline_dms_task_time_out" {
   default     = 86400 # 24 hours
 }
 
-variable "pipeline_landing_lambda_time_out" {
-  description = "Landing Zone Lambda Tasks Timeout"
+variable "landing_zone_antivirus_check_lambda_timeout_in_seconds" {
+  description = "Timeout for the Landing Zone Antivirus Check Lambda in seconds"
+  type        = number
+  default     = 1200 # 20 minutes
+}
+
+variable "landing_zone_processing_lambda_timeout_in_seconds" {
+  description = "Landing zone processing Lambda timeout in seconds."
   type        = number
   default     = 1200 # 20 minutes
 }

--- a/modules/domains/ingestion-pipeline/variables.tf
+++ b/modules/domains/ingestion-pipeline/variables.tf
@@ -9,6 +9,11 @@ variable "file_transfer_in" {
   description = "Determines if the pipeline is for File Transfer In, True or False?"
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.file_transfer_in ? var.batch_only : true
+    error_message = "File Transfer In pipeline can only be created when batch_only = true"
+  }
 }
 
 variable "batch_only" {

--- a/modules/domains/landing-zone-processing-lambda/lambda.tf
+++ b/modules/domains/landing-zone-processing-lambda/lambda.tf
@@ -19,6 +19,8 @@ module "landing_zone_processing_lambda" {
   env_vars = {
     OUTPUT_BUCKET                 = var.output_bucket_name
     SCHEMA_REGISTRY_BUCKET        = var.schema_registry_bucket_name
+    VIOLATIONS_BUCKET             = var.violations_bucket_name
+    VIOLATIONS_PATH               = var.violations_path
     CHARSET                       = var.csv_charset
     NUMBER_OF_HEADER_ROWS_TO_SKIP = var.number_of_csv_header_rows_to_skip
     LOG_CSV                       = var.log_csv

--- a/modules/domains/landing-zone-processing-lambda/lambda.tf
+++ b/modules/domains/landing-zone-processing-lambda/lambda.tf
@@ -15,7 +15,6 @@ module "landing_zone_processing_lambda" {
   tracing        = var.lambda_tracing
   timeout        = var.lambda_timeout_in_seconds
   memory_size    = var.memory_size_mb
-  lambda_trigger = true
 
   env_vars = {
     OUTPUT_BUCKET                 = var.output_bucket_name

--- a/modules/domains/landing-zone-processing-lambda/lambda.tf
+++ b/modules/domains/landing-zone-processing-lambda/lambda.tf
@@ -5,16 +5,16 @@ module "landing_zone_processing_lambda" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/ministryofjustice/modernisation-platform-environments.git//terraform/environments/digital-prison-reporting/modules/lambdas/generic?ref=main"
 
-  enable_lambda  = var.enable
-  name           = var.name
-  s3_bucket      = var.lambda_code_s3_bucket
-  s3_key         = var.lambda_code_s3_key
-  handler        = var.lambda_handler
-  runtime        = var.lambda_runtime
-  policies       = var.policies
-  tracing        = var.lambda_tracing
-  timeout        = var.lambda_timeout_in_seconds
-  memory_size    = var.memory_size_mb
+  enable_lambda = var.enable
+  name          = var.name
+  s3_bucket     = var.lambda_code_s3_bucket
+  s3_key        = var.lambda_code_s3_key
+  handler       = var.lambda_handler
+  runtime       = var.lambda_runtime
+  policies      = var.policies
+  tracing       = var.lambda_tracing
+  timeout       = var.lambda_timeout_in_seconds
+  memory_size   = var.memory_size_mb
 
   env_vars = {
     OUTPUT_BUCKET                 = var.output_bucket_name

--- a/modules/domains/landing-zone-processing-lambda/lambda.tf
+++ b/modules/domains/landing-zone-processing-lambda/lambda.tf
@@ -21,6 +21,7 @@ module "landing_zone_processing_lambda" {
     SCHEMA_REGISTRY_BUCKET        = var.schema_registry_bucket_name
     CHARSET                       = var.csv_charset
     NUMBER_OF_HEADER_ROWS_TO_SKIP = var.number_of_csv_header_rows_to_skip
+    LOG_CSV                       = var.log_csv
   }
 
   log_retention_in_days = var.lambda_log_retention_in_days

--- a/modules/domains/landing-zone-processing-lambda/outputs.tf
+++ b/modules/domains/landing-zone-processing-lambda/outputs.tf
@@ -1,3 +1,8 @@
 output "lambda_function_arn" {
   value = module.landing_zone_processing_lambda.lambda_function
 }
+
+output "lambda_name" {
+  description = "The name of the Lambda function"
+  value       = var.enable ? module.landing_zone_processing_lambda.lambda_name : ""
+}

--- a/modules/domains/landing-zone-processing-lambda/variables.tf
+++ b/modules/domains/landing-zone-processing-lambda/variables.tf
@@ -28,6 +28,16 @@ variable "schema_registry_bucket_name" {
   type        = string
 }
 
+variable "violations_bucket_name" {
+  description = "The name of the bucket where files are moved to when they are classified as violations"
+  type        = string
+}
+
+variable "violations_path" {
+  description = "The path in the violations bucket where violations files are moved to, i.e. the prefix in the violations bucket where files classed as violations are moved to"
+  type        = string
+}
+
 variable "csv_charset" {
   description = "The charset of the input CSV files"
   type        = string

--- a/modules/domains/landing-zone-processing-lambda/variables.tf
+++ b/modules/domains/landing-zone-processing-lambda/variables.tf
@@ -40,6 +40,12 @@ variable "number_of_csv_header_rows_to_skip" {
   default     = 0
 }
 
+variable "log_csv" {
+  description = "Whether to log all lines of the CSV file during landing zone processing"
+  type        = bool
+  default     = false
+}
+
 variable "lambda_handler" {
   description = "Notification Lambda Handler"
   type        = string


### PR DESCRIPTION
- Add file transfer in option to ingestion pipeline
  - It replaces the DMS related steps with the lambdas as per the solution design here: https://dsdmoj.atlassian.net/wiki/spaces/DPR/pages/5577015343/File+Transfer+In+Push+Solution+Design
  - It is only currently implemented as a batch process for files manually uploaded to the S3 Landing Zone bucket - CDC will come later as part of another jira
- Remove bucket notification triggers from antivirus lambda
- Remove lambda trigger var from processing lambda.

The Ingestion pipeline for File Transfer In has the following steps:

![image](https://github.com/user-attachments/assets/6bbce453-2e8d-4b21-bb89-02cd7e745372)
 