### PR TITLE
DPR2-2083: Default schedule timezone to UTC

### DIFF
--- a/modules/eventbridge_trigger/variables.tf
+++ b/modules/eventbridge_trigger/variables.tf
@@ -40,7 +40,7 @@ variable "schedule_expression" {
 variable "schedule_expression_timezone" {
   type        = string
   description = "Schedule expression time zone for the eventbridge trigger"
-  default     = "Europe/London"
+  default     = "UTC"
 }
 
 variable "arn" {


### PR DESCRIPTION
This PR defaults the timezone used for the Eventbridge schedule to UTC when none is provided.