### PR TITLE
DHS-422: Make replication-instance-storage configurable

### DIFF
--- a/modules/domains/dms-instance/dms-instance.tf
+++ b/modules/domains/dms-instance/dms-instance.tf
@@ -8,6 +8,7 @@ module "dms_instance" {
   setup_dms_instance           = var.setup_dms_instance
   replication_instance_version = var.replication_instance_version
   replication_instance_class   = var.replication_instance_class
+  replication_instance_storage = var.replication_instance_storage
   subnet_ids                   = var.subnet_ids
   vpc_cidr                     = var.vpc_cidr
   vpc                          = var.vpc

--- a/modules/domains/dms-instance/variables.tf
+++ b/modules/domains/dms-instance/variables.tf
@@ -57,6 +57,12 @@ variable "replication_instance_class" {
   default     = "dms.t3.micro"
 }
 
+variable "replication_instance_storage" {
+  description = "Size of the replication instance in GB"
+  type        = string
+  default     = "10"
+}
+
 variable "allow_major_version_upgrade" {
   description = "Indicates that major version upgrades are allowed"
   type        = bool


### PR DESCRIPTION
The common replication instance in production is running low on memory. This PR makes the storage value configurable so it can be increased to 20GB.