### PR TITLE
DHS-457: Deactivate archive job schedule during maintenance

### DIFF
--- a/modules/domains/maintenance-pipeline/variables.tf
+++ b/modules/domains/maintenance-pipeline/variables.tf
@@ -85,6 +85,16 @@ variable "glue_archive_job" {
   type        = string
 }
 
+variable "glue_trigger_activation_job" {
+  description = "Name of job to which activates/deactivates a glue trigger"
+  type        = string
+}
+
+variable "archive_job_trigger_name" {
+  description = "Name of the trigger for a glue trigger"
+  type        = string
+}
+
 variable "compaction_structured_worker_type" {
   description = "(Optional) Worker type to use for the compaction job in structured zone"
   type        = string


### PR DESCRIPTION
This PR deactivates the archive job schedule during the maintenance window to avoid the `Max concurrent runs exceeded` error which occurs when the `Archive Raw Data` step attempts to run while the periodic archive job is currently running or vice versa.