### PR TITLE
DHS-677: Fix Reload pipeline

### DIFF
--- a/modules/domains/reload-pipeline/steps.tf
+++ b/modules/domains/reload-pipeline/steps.tf
@@ -472,7 +472,7 @@ locals {
           "--dpr.cdc.dms.replication.task.id" : var.cdc_replication_task_id
         }
       },
-      "Next" : local.run_glue_batch_job.StepName
+      "Next" : local.run_batch_processes.StepName
     }
   }
 


### PR DESCRIPTION
This PR fixes the terraform apply for the state function error below:
```
│ Error: invalid Step Functions State Machine definition: ERROR (MISSING_TRANSITION_TARGET): Missing 'Next' target: Run Glue Batch Job
│ ERROR (MISSING_TRANSITION_TARGET): State "Run Batch Processes" is not reachable.
│ 
│   with module.reload-pipeline["course-attendance"].module.reload_pipeline[0].aws_sfn_state_machine.data_ingestion_step_function[0],
│   on .terraform/modules/reload-pipeline/modules/step_function/main.tf line 1, in resource "aws_sfn_state_machine" "data_ingestion_step_function":
│    1: resource "aws_sfn_state_machine" "data_ingestion_step_function" {
```

This has been tested to be working via this PR https://github.com/ministryofjustice/digital-prison-reporting-domains/pull/613