### PR TITLE
DHS-681: Add default for max_session_duration_seconds

### DIFF
--- a/modules/domains/dms-instance/dms-instance.tf
+++ b/modules/domains/dms-instance/dms-instance.tf
@@ -15,6 +15,7 @@ module "dms_instance" {
   short_name                   = var.short_name
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   custom_metric_namespace      = var.custom_metric_namespace
+  max_session_duration_seconds = null
 
   dms_log_retention_in_days = var.dms_log_retention_in_days
 

--- a/modules/domains/dms-task/dms-task.tf
+++ b/modules/domains/dms-task/dms-task.tf
@@ -2,19 +2,20 @@
 module "dms_task" {
   source = "../../dms_s3_v2"
 
-  enable_replication_task   = var.enable_replication_task
-  name                      = var.name
-  project_id                = var.project_id
-  env                       = var.env
-  dms_replication_instance  = var.dms_replication_instance
-  migration_type            = var.migration_type
-  replication_task_settings = var.replication_task_settings
-  table_mappings            = var.table_mappings
-  rename_rule_source_schema = var.rename_rule_source_schema
-  rename_rule_output_space  = var.rename_rule_output_space
-  dms_source_endpoint       = var.dms_source_endpoint
-  dms_target_endpoint       = var.dms_target_endpoint
-  short_name                = var.short_name
+  enable_replication_task      = var.enable_replication_task
+  name                         = var.name
+  project_id                   = var.project_id
+  env                          = var.env
+  dms_replication_instance     = var.dms_replication_instance
+  migration_type               = var.migration_type
+  replication_task_settings    = var.replication_task_settings
+  table_mappings               = var.table_mappings
+  rename_rule_source_schema    = var.rename_rule_source_schema
+  rename_rule_output_space     = var.rename_rule_output_space
+  dms_source_endpoint          = var.dms_source_endpoint
+  dms_target_endpoint          = var.dms_target_endpoint
+  short_name                   = var.short_name
+  max_session_duration_seconds = null
 
   tags = var.tags
 }


### PR DESCRIPTION
This PR:
- Sets the max_session_duration_seconds to 12 hours for NOMIS DMS endpoint
- Keeps the value at 1 hour for DPS services